### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -3,6 +3,9 @@
 
 name: Swift
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/platacard/gito/security/code-scanning/1](https://github.com/platacard/gito/security/code-scanning/1)

In general, the problem is fixed by explicitly defining a `permissions` block in the workflow or at the job level so that the `GITHUB_TOKEN` has only the minimal required access. For a build-and-test workflow that just checks out code and runs `swift build` and `swift test`, read-only access to repository contents is sufficient.

The best fix here, without changing existing functionality, is to add a `permissions` block at the top level of the workflow (so it applies to all jobs) specifying `contents: read`. This will ensure that the `build` job still has enough permission for `actions/checkout@v4` to fetch the code, while preventing unintended write operations with the `GITHUB_TOKEN`. Concretely, in `.github/workflows/swift.yml`, between the existing `name: Swift` (line 4) and the `on:` block (line 6), insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed, since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
