### PR TITLE
feat: cherry-pick, rev-list, merge-base, is-ancestor operations

### DIFF
--- a/Sources/Gito/Gito+CherryPick.swift
+++ b/Sources/Gito/Gito+CherryPick.swift
@@ -5,38 +5,29 @@ public enum CherryPickOutcome: Sendable, Equatable {
     case applied
     case conflict(output: String)
     case empty
-    case skipped
-    case aborted
-}
-
-public enum CherryPickAction: Sendable, Equatable {
-    case apply(hash: String, recordOrigin: Bool = true)
-    case skip
-    case abort
 }
 
 public extension Gito {
     @discardableResult
-    func cherryPick(_ action: CherryPickAction) throws -> CherryPickOutcome {
-        switch action {
-        case let .apply(hash, recordOrigin):
-            let cmd = recordOrigin ? "git cherry-pick -x \(hash)" : "git cherry-pick \(hash)"
-            do {
-                try Shell.command(cmd, in: folder, options: [.printOutput]).run()
-                return .applied
-            } catch {
-                guard case let .commandFailed(_, exitCode, output) = error, exitCode == 1 else {
-                    throw error
-                }
-                let unmerged = (try? Shell.command("git ls-files --unmerged", in: folder).run()) ?? ""
-                return unmerged.isEmpty ? .empty : .conflict(output: output)
+    func cherryPick(hash: String, recordOrigin: Bool = true) throws -> CherryPickOutcome {
+        let cmd = recordOrigin ? "git cherry-pick -x \(hash)" : "git cherry-pick \(hash)"
+        do {
+            try Shell.command(cmd, in: folder, options: [.printOutput]).run()
+            return .applied
+        } catch {
+            guard case let .commandFailed(_, exitCode, output) = error, exitCode == 1 else {
+                throw error
             }
-        case .skip:
-            try Shell.command("git cherry-pick --skip", in: folder, options: [.printOutput]).run()
-            return .skipped
-        case .abort:
-            try Shell.command("git cherry-pick --abort", in: folder, options: [.printOutput]).run()
-            return .aborted
+            let unmerged = (try? Shell.command("git ls-files --unmerged", in: folder).run()) ?? ""
+            return unmerged.isEmpty ? .empty : .conflict(output: output)
         }
+    }
+
+    func cherryPickSkip() throws {
+        try Shell.command("git cherry-pick --skip", in: folder, options: [.printOutput]).run()
+    }
+
+    func cherryPickAbort() throws {
+        try Shell.command("git cherry-pick --abort", in: folder, options: [.printOutput]).run()
     }
 }

--- a/Sources/Gito/Gito+CherryPick.swift
+++ b/Sources/Gito/Gito+CherryPick.swift
@@ -5,31 +5,38 @@ public enum CherryPickOutcome: Sendable, Equatable {
     case applied
     case conflict(output: String)
     case empty
+    case skipped
+    case aborted
 }
 
-// Three separate methods. cherryPick has meaningful exit-1 outcomes
-// (conflict, empty); skip and abort don't.
+public enum CherryPickAction: Sendable, Equatable {
+    case apply(hash: String, recordOrigin: Bool = true)
+    case skip
+    case abort
+}
+
 public extension Gito {
     @discardableResult
-    func cherryPick(hash: String, recordOrigin: Bool = true) throws -> CherryPickOutcome {
-        let cmd = recordOrigin ? "git cherry-pick -x \(hash)" : "git cherry-pick \(hash)"
-        do {
-            try Shell.command(cmd, in: folder, options: [.printOutput]).run()
-            return .applied
-        } catch {
-            if case let ShellRunner.Error.commandFailed(_, 1, output) = error {
-                if output.contains("now empty") { return .empty }
-                return .conflict(output: output)
+    func cherryPick(_ action: CherryPickAction) throws -> CherryPickOutcome {
+        switch action {
+        case let .apply(hash, recordOrigin):
+            let cmd = recordOrigin ? "git cherry-pick -x \(hash)" : "git cherry-pick \(hash)"
+            do {
+                try Shell.command(cmd, in: folder, options: [.printOutput]).run()
+                return .applied
+            } catch {
+                guard case let .commandFailed(_, exitCode, output) = error, exitCode == 1 else {
+                    throw error
+                }
+                let unmerged = (try? Shell.command("git ls-files --unmerged", in: folder).run()) ?? ""
+                return unmerged.isEmpty ? .empty : .conflict(output: output)
             }
-            throw error
+        case .skip:
+            try Shell.command("git cherry-pick --skip", in: folder, options: [.printOutput]).run()
+            return .skipped
+        case .abort:
+            try Shell.command("git cherry-pick --abort", in: folder, options: [.printOutput]).run()
+            return .aborted
         }
-    }
-
-    func cherryPickSkip() throws {
-        try Shell.command("git cherry-pick --skip", in: folder, options: [.printOutput]).run()
-    }
-
-    func cherryPickAbort() throws {
-        try Shell.command("git cherry-pick --abort", in: folder, options: [.printOutput]).run()
     }
 }

--- a/Sources/Gito/Gito+CherryPick.swift
+++ b/Sources/Gito/Gito+CherryPick.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Corredor
+
+public enum CherryPickOutcome: Sendable, Equatable {
+    case applied
+    case conflict(output: String)
+    case empty
+}
+
+// Three separate methods. cherryPick has meaningful exit-1 outcomes
+// (conflict, empty); skip and abort don't.
+public extension Gito {
+    @discardableResult
+    func cherryPick(hash: String, recordOrigin: Bool = true) throws -> CherryPickOutcome {
+        let cmd = recordOrigin ? "git cherry-pick -x \(hash)" : "git cherry-pick \(hash)"
+        do {
+            try Shell.command(cmd, in: folder, options: [.printOutput]).run()
+            return .applied
+        } catch {
+            if case let ShellRunner.Error.commandFailed(_, 1, output) = error {
+                if output.contains("now empty") { return .empty }
+                return .conflict(output: output)
+            }
+            throw error
+        }
+    }
+
+    func cherryPickSkip() throws {
+        try Shell.command("git cherry-pick --skip", in: folder, options: [.printOutput]).run()
+    }
+
+    func cherryPickAbort() throws {
+        try Shell.command("git cherry-pick --abort", in: folder, options: [.printOutput]).run()
+    }
+}

--- a/Sources/Gito/Gito+MergeBase.swift
+++ b/Sources/Gito/Gito+MergeBase.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Corredor
+
+public extension Gito {
+    /// Best common ancestor of `a` and `b`. Returns `nil` when histories are
+    /// unrelated (git exits 1 with no output).
+    func mergeBase(_ a: String, _ b: String) throws -> String? {
+        do {
+            let out = try Shell.command("git merge-base \(a) \(b)", in: folder).run()
+            return out.isEmpty ? nil : out
+        } catch {
+            if case ShellRunner.Error.commandFailed(_, 1, _) = error { return nil }
+            throw error
+        }
+    }
+
+    /// `true` if `commit` is reachable from `ref`. Distinguishes
+    /// "not an ancestor" (exit 1, returns false) from a missing commit
+    /// (exit >= 2, throws).
+    func isAncestor(_ commit: String, of ref: String) throws -> Bool {
+        do {
+            try Shell.command("git merge-base --is-ancestor \(commit) \(ref)", in: folder).run()
+            return true
+        } catch {
+            if case ShellRunner.Error.commandFailed(_, 1, _) = error { return false }
+            throw error
+        }
+    }
+}

--- a/Sources/Gito/Gito+MergeBase.swift
+++ b/Sources/Gito/Gito+MergeBase.swift
@@ -9,8 +9,10 @@ public extension Gito {
             let out = try Shell.command("git merge-base \(a) \(b)", in: folder).run()
             return out.isEmpty ? nil : out
         } catch {
-            if case ShellRunner.Error.commandFailed(_, 1, _) = error { return nil }
-            throw error
+            guard case let .commandFailed(_, exitCode, _) = error, exitCode == 1 else {
+                throw error
+            }
+            return nil
         }
     }
 
@@ -22,8 +24,10 @@ public extension Gito {
             try Shell.command("git merge-base --is-ancestor \(commit) \(ref)", in: folder).run()
             return true
         } catch {
-            if case ShellRunner.Error.commandFailed(_, 1, _) = error { return false }
-            throw error
+            guard case let .commandFailed(_, exitCode, _) = error, exitCode == 1 else {
+                throw error
+            }
+            return false
         }
     }
 }

--- a/Sources/Gito/Gito+RevList.swift
+++ b/Sources/Gito/Gito+RevList.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Corredor
+
+public extension Gito {
+    func revList(range: String, reverse: Bool = false, format: String? = nil) throws -> String {
+        var parts = ["git rev-list"]
+        if reverse { parts.append("--reverse") }
+        parts.append(range)
+        if let format { parts.append("--format='\(format)'") }
+        return try Shell.command(parts.joined(separator: " "), in: folder).run()
+    }
+}

--- a/Sources/Gito/Gito.swift
+++ b/Sources/Gito/Gito.swift
@@ -10,9 +10,9 @@ import Cronista
 public class Gito {
     private var logger = Cronista(module: "Gito", category: "default")
     private var env: [String: String] { ProcessInfo.processInfo.environment }
-    
-    private let folder: URL
-    
+
+    let folder: URL
+
     public nonisolated init(
         in folder: URL = URL(filePath: FileManager.default.currentDirectoryPath)
     ) {
@@ -109,6 +109,15 @@ public extension Gito {
     func commit(message: String) throws {
         try Shell.command("git commit -m \"\(message)\"", in: folder, options: [.printOutput]).run()
     }
+
+    /// Variant that supports skipping pre-commit hooks and empty commits.
+    func commit(message: String, noVerify: Bool, allowEmpty: Bool = false) throws {
+        var parts = ["git commit"]
+        if noVerify { parts.append("--no-verify") }
+        if allowEmpty { parts.append("--allow-empty") }
+        parts.append("-m \"\(message)\"")
+        try Shell.command(parts.joined(separator: " "), in: folder, options: [.printOutput]).run()
+    }
     
     func push(options: [String], dst: String = "", branch: String = "") throws {
         try Shell.command("git push \(options.joined(separator: " ")) \(dst) \"\(branch)\"", in: folder, options: [.printOutput]).run()
@@ -120,6 +129,16 @@ public extension Gito {
     
     func checkout(branch: String, options: [String] = []) throws {
         try Shell.command("git checkout \(options.joined(separator: " ")) \"\(branch)\"", in: folder, options: [.printOutput]).run()
+    }
+
+    /// Variant that takes a starting-point ref (e.g. `git checkout -B feature origin/main`).
+    func checkout(branch: String, options: [String], startPoint: String) throws {
+        let opts = options.joined(separator: " ")
+        try Shell.command(
+            "git checkout \(opts) \"\(branch)\" \"\(startPoint)\"",
+            in: folder,
+            options: [.printOutput]
+        ).run()
     }
     
     /// Fetches from remote repositories.

--- a/Tests/GitoTests/CherryPickTests.swift
+++ b/Tests/GitoTests/CherryPickTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import XCTest
+import Corredor
+@testable import Gito
+
+final class CherryPickTests: XCTestCase {
+    var repo: TempRepo!
+    var sut: Gito!
+
+    override func setUpWithError() throws {
+        repo = try TempRepo()
+        sut = Gito(in: repo.url)
+    }
+
+    override func tearDownWithError() throws {
+        try repo.tearDown()
+    }
+
+    func test_pick_appliesCleanly() throws {
+        let main = try repo.head()
+        try repo.git("checkout", "-b", "feature")
+        let featureHash = try repo.commitFile(path: "a.txt", content: "x", message: "feature commit")
+        try repo.git("checkout", "main")
+        XCTAssertEqual(try repo.head(), main)
+
+        let outcome = try sut.cherryPick(hash: featureHash)
+
+        XCTAssertEqual(outcome, .applied)
+        XCTAssertNotEqual(try repo.head(), main)
+        let log = try repo.git("log", "-1", "--format=%s")
+        XCTAssertTrue(log.contains("feature commit"))
+    }
+
+    func test_pick_recordOriginAddsXLine() throws {
+        try repo.git("checkout", "-b", "feature")
+        let featureHash = try repo.commitFile(path: "a.txt", content: "x", message: "with -x")
+        try repo.git("checkout", "main")
+
+        try sut.cherryPick(hash: featureHash, recordOrigin: true)
+
+        let body = try repo.git("log", "-1", "--format=%B")
+        XCTAssertTrue(body.contains("(cherry picked from commit"))
+    }
+
+    func test_pick_conflict_returnsConflictOutcome() throws {
+        try repo.commitFile(path: "shared.txt", content: "main\n", message: "main version")
+        let mainTip = try repo.head()
+        try repo.git("checkout", "-b", "other", "HEAD~1")
+        let otherHash = try repo.commitFile(path: "shared.txt", content: "other\n", message: "other version")
+        try repo.git("checkout", "main")
+        XCTAssertEqual(try repo.head(), mainTip)
+
+        let outcome = try sut.cherryPick(hash: otherHash)
+
+        guard case .conflict = outcome else {
+            return XCTFail("expected .conflict, got \(outcome)")
+        }
+        let cherryPickHead = repo.url.appendingPathComponent(".git/CHERRY_PICK_HEAD")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cherryPickHead.path))
+    }
+
+    func test_pick_emptyCommit_returnsEmpty() throws {
+        try repo.commitFile(path: "a.txt", content: "shared\n", message: "main writes shared")
+        try repo.git("checkout", "-b", "branch", "HEAD~1")
+        let dupHash = try repo.commitFile(path: "a.txt", content: "shared\n", message: "branch writes the same")
+        try repo.git("checkout", "main")
+
+        let outcome = try sut.cherryPick(hash: dupHash)
+        XCTAssertEqual(outcome, .empty)
+
+        try sut.cherryPickSkip()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: repo.url.appendingPathComponent(".git/CHERRY_PICK_HEAD").path))
+    }
+
+    func test_skip_clearsConflictedState() throws {
+        try repo.commitFile(path: "f.txt", content: "main\n", message: "m")
+        try repo.git("checkout", "-b", "b", "HEAD~1")
+        let h = try repo.commitFile(path: "f.txt", content: "b\n", message: "b")
+        try repo.git("checkout", "main")
+        _ = try sut.cherryPick(hash: h)
+
+        try sut.cherryPickSkip()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: repo.url.appendingPathComponent(".git/CHERRY_PICK_HEAD").path))
+    }
+
+    func test_abort_restoresWorkingTree() throws {
+        try repo.commitFile(path: "f.txt", content: "main\n", message: "m")
+        let mainTip = try repo.head()
+        try repo.git("checkout", "-b", "b", "HEAD~1")
+        let h = try repo.commitFile(path: "f.txt", content: "b\n", message: "b")
+        try repo.git("checkout", "main")
+        _ = try sut.cherryPick(hash: h)
+
+        try sut.cherryPickAbort()
+        XCTAssertEqual(try repo.head(), mainTip)
+        let content = try String(contentsOf: repo.url.appendingPathComponent("f.txt"))
+        XCTAssertEqual(content, "main\n")
+    }
+
+    func test_pick_invalidHash_throws() throws {
+        XCTAssertThrowsError(try sut.cherryPick(hash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")) { error in
+            guard case ShellRunner.Error.commandFailed = error else {
+                return XCTFail("expected ShellRunner.Error.commandFailed, got \(error)")
+            }
+        }
+    }
+}

--- a/Tests/GitoTests/CherryPickTests.swift
+++ b/Tests/GitoTests/CherryPickTests.swift
@@ -1,107 +1,114 @@
 import Foundation
-import XCTest
+import Testing
 import Corredor
 @testable import Gito
 
-final class CherryPickTests: XCTestCase {
-    var repo: TempRepo!
-    var sut: Gito!
+@Suite
+final class CherryPickTests {
+    let repo: TempRepo
+    let sut: Gito
 
-    override func setUpWithError() throws {
+    init() throws {
         repo = try TempRepo()
         sut = Gito(in: repo.url)
     }
 
-    override func tearDownWithError() throws {
-        try repo.tearDown()
+    deinit {
+        try? repo.tearDown()
     }
 
-    func test_pick_appliesCleanly() throws {
+    @Test
+    func pick_appliesCleanly() throws {
         let main = try repo.head()
         try repo.git("checkout", "-b", "feature")
         let featureHash = try repo.commitFile(path: "a.txt", content: "x", message: "feature commit")
         try repo.git("checkout", "main")
-        XCTAssertEqual(try repo.head(), main)
+        #expect(try repo.head() == main)
 
-        let outcome = try sut.cherryPick(hash: featureHash)
+        let outcome = try sut.cherryPick(.apply(hash: featureHash))
 
-        XCTAssertEqual(outcome, .applied)
-        XCTAssertNotEqual(try repo.head(), main)
+        #expect(outcome == .applied)
+        #expect(try repo.head() != main)
         let log = try repo.git("log", "-1", "--format=%s")
-        XCTAssertTrue(log.contains("feature commit"))
+        #expect(log.contains("feature commit"))
     }
 
-    func test_pick_recordOriginAddsXLine() throws {
+    @Test
+    func pick_recordOriginAddsXLine() throws {
         try repo.git("checkout", "-b", "feature")
         let featureHash = try repo.commitFile(path: "a.txt", content: "x", message: "with -x")
         try repo.git("checkout", "main")
 
-        try sut.cherryPick(hash: featureHash, recordOrigin: true)
+        try sut.cherryPick(.apply(hash: featureHash, recordOrigin: true))
 
         let body = try repo.git("log", "-1", "--format=%B")
-        XCTAssertTrue(body.contains("(cherry picked from commit"))
+        #expect(body.contains("(cherry picked from commit"))
     }
 
-    func test_pick_conflict_returnsConflictOutcome() throws {
+    @Test
+    func pick_conflict_returnsConflictOutcome() throws {
         try repo.commitFile(path: "shared.txt", content: "main\n", message: "main version")
         let mainTip = try repo.head()
         try repo.git("checkout", "-b", "other", "HEAD~1")
         let otherHash = try repo.commitFile(path: "shared.txt", content: "other\n", message: "other version")
         try repo.git("checkout", "main")
-        XCTAssertEqual(try repo.head(), mainTip)
+        #expect(try repo.head() == mainTip)
 
-        let outcome = try sut.cherryPick(hash: otherHash)
+        let outcome = try sut.cherryPick(.apply(hash: otherHash))
 
         guard case .conflict = outcome else {
-            return XCTFail("expected .conflict, got \(outcome)")
+            Issue.record("expected .conflict, got \(outcome)")
+            return
         }
         let cherryPickHead = repo.url.appendingPathComponent(".git/CHERRY_PICK_HEAD")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: cherryPickHead.path))
+        #expect(FileManager.default.fileExists(atPath: cherryPickHead.path))
     }
 
-    func test_pick_emptyCommit_returnsEmpty() throws {
+    @Test
+    func pick_emptyCommit_returnsEmpty() throws {
         try repo.commitFile(path: "a.txt", content: "shared\n", message: "main writes shared")
         try repo.git("checkout", "-b", "branch", "HEAD~1")
         let dupHash = try repo.commitFile(path: "a.txt", content: "shared\n", message: "branch writes the same")
         try repo.git("checkout", "main")
 
-        let outcome = try sut.cherryPick(hash: dupHash)
-        XCTAssertEqual(outcome, .empty)
+        let outcome = try sut.cherryPick(.apply(hash: dupHash))
+        #expect(outcome == .empty)
 
-        try sut.cherryPickSkip()
-        XCTAssertFalse(FileManager.default.fileExists(atPath: repo.url.appendingPathComponent(".git/CHERRY_PICK_HEAD").path))
+        try sut.cherryPick(.skip)
+        #expect(!FileManager.default.fileExists(atPath: repo.url.appendingPathComponent(".git/CHERRY_PICK_HEAD").path))
     }
 
-    func test_skip_clearsConflictedState() throws {
+    @Test
+    func skip_clearsConflictedState() throws {
         try repo.commitFile(path: "f.txt", content: "main\n", message: "m")
         try repo.git("checkout", "-b", "b", "HEAD~1")
         let h = try repo.commitFile(path: "f.txt", content: "b\n", message: "b")
         try repo.git("checkout", "main")
-        _ = try sut.cherryPick(hash: h)
+        _ = try sut.cherryPick(.apply(hash: h))
 
-        try sut.cherryPickSkip()
-        XCTAssertFalse(FileManager.default.fileExists(atPath: repo.url.appendingPathComponent(".git/CHERRY_PICK_HEAD").path))
+        try sut.cherryPick(.skip)
+        #expect(!FileManager.default.fileExists(atPath: repo.url.appendingPathComponent(".git/CHERRY_PICK_HEAD").path))
     }
 
-    func test_abort_restoresWorkingTree() throws {
+    @Test
+    func abort_restoresWorkingTree() throws {
         try repo.commitFile(path: "f.txt", content: "main\n", message: "m")
         let mainTip = try repo.head()
         try repo.git("checkout", "-b", "b", "HEAD~1")
         let h = try repo.commitFile(path: "f.txt", content: "b\n", message: "b")
         try repo.git("checkout", "main")
-        _ = try sut.cherryPick(hash: h)
+        _ = try sut.cherryPick(.apply(hash: h))
 
-        try sut.cherryPickAbort()
-        XCTAssertEqual(try repo.head(), mainTip)
-        let content = try String(contentsOf: repo.url.appendingPathComponent("f.txt"))
-        XCTAssertEqual(content, "main\n")
+        try sut.cherryPick(.abort)
+        #expect(try repo.head() == mainTip)
+        let content = try String(contentsOf: repo.url.appendingPathComponent("f.txt"), encoding: .utf8)
+        #expect(content == "main\n")
     }
 
-    func test_pick_invalidHash_throws() throws {
-        XCTAssertThrowsError(try sut.cherryPick(hash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")) { error in
-            guard case ShellRunner.Error.commandFailed = error else {
-                return XCTFail("expected ShellRunner.Error.commandFailed, got \(error)")
-            }
+    @Test
+    func pick_invalidHash_throws() {
+        #expect(throws: ShellRunner.Error.self) {
+            try sut.cherryPick(.apply(hash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"))
         }
     }
 }

--- a/Tests/GitoTests/CherryPickTests.swift
+++ b/Tests/GitoTests/CherryPickTests.swift
@@ -25,7 +25,7 @@ final class CherryPickTests {
         try repo.git("checkout", "main")
         #expect(try repo.head() == main)
 
-        let outcome = try sut.cherryPick(.apply(hash: featureHash))
+        let outcome = try sut.cherryPick(hash: featureHash)
 
         #expect(outcome == .applied)
         #expect(try repo.head() != main)
@@ -39,7 +39,7 @@ final class CherryPickTests {
         let featureHash = try repo.commitFile(path: "a.txt", content: "x", message: "with -x")
         try repo.git("checkout", "main")
 
-        try sut.cherryPick(.apply(hash: featureHash, recordOrigin: true))
+        try sut.cherryPick(hash: featureHash, recordOrigin: true)
 
         let body = try repo.git("log", "-1", "--format=%B")
         #expect(body.contains("(cherry picked from commit"))
@@ -54,7 +54,7 @@ final class CherryPickTests {
         try repo.git("checkout", "main")
         #expect(try repo.head() == mainTip)
 
-        let outcome = try sut.cherryPick(.apply(hash: otherHash))
+        let outcome = try sut.cherryPick(hash: otherHash)
 
         guard case .conflict = outcome else {
             Issue.record("expected .conflict, got \(outcome)")
@@ -71,10 +71,10 @@ final class CherryPickTests {
         let dupHash = try repo.commitFile(path: "a.txt", content: "shared\n", message: "branch writes the same")
         try repo.git("checkout", "main")
 
-        let outcome = try sut.cherryPick(.apply(hash: dupHash))
+        let outcome = try sut.cherryPick(hash: dupHash)
         #expect(outcome == .empty)
 
-        try sut.cherryPick(.skip)
+        try sut.cherryPickSkip()
         #expect(!FileManager.default.fileExists(atPath: repo.url.appendingPathComponent(".git/CHERRY_PICK_HEAD").path))
     }
 
@@ -84,9 +84,9 @@ final class CherryPickTests {
         try repo.git("checkout", "-b", "b", "HEAD~1")
         let h = try repo.commitFile(path: "f.txt", content: "b\n", message: "b")
         try repo.git("checkout", "main")
-        _ = try sut.cherryPick(.apply(hash: h))
+        _ = try sut.cherryPick(hash: h)
 
-        try sut.cherryPick(.skip)
+        try sut.cherryPickSkip()
         #expect(!FileManager.default.fileExists(atPath: repo.url.appendingPathComponent(".git/CHERRY_PICK_HEAD").path))
     }
 
@@ -97,9 +97,9 @@ final class CherryPickTests {
         try repo.git("checkout", "-b", "b", "HEAD~1")
         let h = try repo.commitFile(path: "f.txt", content: "b\n", message: "b")
         try repo.git("checkout", "main")
-        _ = try sut.cherryPick(.apply(hash: h))
+        _ = try sut.cherryPick(hash: h)
 
-        try sut.cherryPick(.abort)
+        try sut.cherryPickAbort()
         #expect(try repo.head() == mainTip)
         let content = try String(contentsOf: repo.url.appendingPathComponent("f.txt"), encoding: .utf8)
         #expect(content == "main\n")
@@ -108,7 +108,7 @@ final class CherryPickTests {
     @Test
     func pick_invalidHash_throws() {
         #expect(throws: ShellRunner.Error.self) {
-            try sut.cherryPick(.apply(hash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"))
+            try sut.cherryPick(hash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
         }
     }
 }

--- a/Tests/GitoTests/MergeBaseTests.swift
+++ b/Tests/GitoTests/MergeBaseTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import XCTest
+import Corredor
+@testable import Gito
+
+final class MergeBaseTests: XCTestCase {
+    var repo: TempRepo!
+    var sut: Gito!
+
+    override func setUpWithError() throws {
+        repo = try TempRepo()
+        sut = Gito(in: repo.url)
+    }
+
+    override func tearDownWithError() throws {
+        try repo.tearDown()
+    }
+
+    func test_mergeBase_returnsForkPoint() throws {
+        let base = try repo.head()
+        try repo.git("checkout", "-b", "a")
+        try repo.commitFile(path: "a.txt", content: "a", message: "a1")
+        let aTip = try repo.head()
+        try repo.git("checkout", "-b", "b", base)
+        try repo.commitFile(path: "b.txt", content: "b", message: "b1")
+        let bTip = try repo.head()
+
+        let result = try sut.mergeBase(aTip, bTip)
+        XCTAssertEqual(result, base)
+    }
+
+    func test_mergeBase_unrelatedHistories_returnsNil() throws {
+        // Establish a real commit on main first so the orphan branch has
+        // something to diverge from (empty-tree merge-base behaviour varies).
+        try repo.commitFile(path: "main.txt", content: "m\n", message: "main commit")
+        let main = try repo.head()
+
+        try repo.git("checkout", "--orphan", "alien")
+        try repo.git("rm", "-rf", "--cached", ".")
+        try "alien\n".write(to: repo.url.appendingPathComponent("alien.txt"), atomically: true, encoding: .utf8)
+        try repo.git("add", "alien.txt")
+        try repo.git("commit", "-m", "alien root")
+        let alien = try repo.head()
+
+        let result = try sut.mergeBase(alien, main)
+        XCTAssertNil(result)
+    }
+
+    func test_mergeBase_invalidRef_throws() throws {
+        XCTAssertThrowsError(try sut.mergeBase("nope", "HEAD")) { error in
+            guard case ShellRunner.Error.commandFailed = error else {
+                return XCTFail("expected ShellRunner.Error.commandFailed, got \(error)")
+            }
+        }
+    }
+
+    func test_isAncestor_trueForReachable() throws {
+        let base = try repo.head()
+        try repo.commitFile(path: "x.txt", content: "x", message: "x1")
+        let result = try sut.isAncestor(base, of: "HEAD")
+        XCTAssertTrue(result)
+    }
+
+    func test_isAncestor_falseForUnreachable() throws {
+        let base = try repo.head()
+        try repo.git("checkout", "-b", "side")
+        let sideTip = try repo.commitFile(path: "s.txt", content: "s", message: "s1")
+        try repo.git("checkout", "main")
+        _ = base
+
+        let result = try sut.isAncestor(sideTip, of: "main")
+        XCTAssertFalse(result)
+    }
+
+    func test_isAncestor_invalidRef_throws() throws {
+        XCTAssertThrowsError(try sut.isAncestor("HEAD", of: "no-such-branch")) { error in
+            guard case ShellRunner.Error.commandFailed = error else {
+                return XCTFail("expected ShellRunner.Error.commandFailed, got \(error)")
+            }
+        }
+    }
+}

--- a/Tests/GitoTests/MergeBaseTests.swift
+++ b/Tests/GitoTests/MergeBaseTests.swift
@@ -1,22 +1,24 @@
 import Foundation
-import XCTest
+import Testing
 import Corredor
 @testable import Gito
 
-final class MergeBaseTests: XCTestCase {
-    var repo: TempRepo!
-    var sut: Gito!
+@Suite
+final class MergeBaseTests {
+    let repo: TempRepo
+    let sut: Gito
 
-    override func setUpWithError() throws {
+    init() throws {
         repo = try TempRepo()
         sut = Gito(in: repo.url)
     }
 
-    override func tearDownWithError() throws {
-        try repo.tearDown()
+    deinit {
+        try? repo.tearDown()
     }
 
-    func test_mergeBase_returnsForkPoint() throws {
+    @Test
+    func mergeBase_returnsForkPoint() throws {
         let base = try repo.head()
         try repo.git("checkout", "-b", "a")
         try repo.commitFile(path: "a.txt", content: "a", message: "a1")
@@ -26,10 +28,11 @@ final class MergeBaseTests: XCTestCase {
         let bTip = try repo.head()
 
         let result = try sut.mergeBase(aTip, bTip)
-        XCTAssertEqual(result, base)
+        #expect(result == base)
     }
 
-    func test_mergeBase_unrelatedHistories_returnsNil() throws {
+    @Test
+    func mergeBase_unrelatedHistories_returnsNil() throws {
         // Establish a real commit on main first so the orphan branch has
         // something to diverge from (empty-tree merge-base behaviour varies).
         try repo.commitFile(path: "main.txt", content: "m\n", message: "main commit")
@@ -43,25 +46,26 @@ final class MergeBaseTests: XCTestCase {
         let alien = try repo.head()
 
         let result = try sut.mergeBase(alien, main)
-        XCTAssertNil(result)
+        #expect(result == nil)
     }
 
-    func test_mergeBase_invalidRef_throws() throws {
-        XCTAssertThrowsError(try sut.mergeBase("nope", "HEAD")) { error in
-            guard case ShellRunner.Error.commandFailed = error else {
-                return XCTFail("expected ShellRunner.Error.commandFailed, got \(error)")
-            }
+    @Test
+    func mergeBase_invalidRef_throws() {
+        #expect(throws: ShellRunner.Error.self) {
+            try sut.mergeBase("nope", "HEAD")
         }
     }
 
-    func test_isAncestor_trueForReachable() throws {
+    @Test
+    func isAncestor_trueForReachable() throws {
         let base = try repo.head()
         try repo.commitFile(path: "x.txt", content: "x", message: "x1")
         let result = try sut.isAncestor(base, of: "HEAD")
-        XCTAssertTrue(result)
+        #expect(result)
     }
 
-    func test_isAncestor_falseForUnreachable() throws {
+    @Test
+    func isAncestor_falseForUnreachable() throws {
         let base = try repo.head()
         try repo.git("checkout", "-b", "side")
         let sideTip = try repo.commitFile(path: "s.txt", content: "s", message: "s1")
@@ -69,14 +73,13 @@ final class MergeBaseTests: XCTestCase {
         _ = base
 
         let result = try sut.isAncestor(sideTip, of: "main")
-        XCTAssertFalse(result)
+        #expect(!result)
     }
 
-    func test_isAncestor_invalidRef_throws() throws {
-        XCTAssertThrowsError(try sut.isAncestor("HEAD", of: "no-such-branch")) { error in
-            guard case ShellRunner.Error.commandFailed = error else {
-                return XCTFail("expected ShellRunner.Error.commandFailed, got \(error)")
-            }
+    @Test
+    func isAncestor_invalidRef_throws() {
+        #expect(throws: ShellRunner.Error.self) {
+            try sut.isAncestor("HEAD", of: "no-such-branch")
         }
     }
 }

--- a/Tests/GitoTests/RevListTests.swift
+++ b/Tests/GitoTests/RevListTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import XCTest
+import Corredor
+@testable import Gito
+
+final class RevListTests: XCTestCase {
+    var repo: TempRepo!
+    var sut: Gito!
+
+    override func setUpWithError() throws {
+        repo = try TempRepo()
+        sut = Gito(in: repo.url)
+    }
+
+    override func tearDownWithError() throws {
+        try repo.tearDown()
+    }
+
+    func test_revList_listsCommitsInRange() throws {
+        let base = try repo.head()
+        let c1 = try repo.commitFile(path: "1.txt", content: "1", message: "first")
+        let c2 = try repo.commitFile(path: "2.txt", content: "2", message: "second")
+
+        let output = try sut.revList(range: "\(base)..HEAD")
+        let hashes = output.split(separator: "\n").map { String($0) }
+        XCTAssertEqual(hashes, [c2, c1]) // newest first by default
+    }
+
+    func test_revList_reverseGivesOldestFirst() throws {
+        let base = try repo.head()
+        let c1 = try repo.commitFile(path: "1.txt", content: "1", message: "first")
+        let c2 = try repo.commitFile(path: "2.txt", content: "2", message: "second")
+
+        let output = try sut.revList(range: "\(base)..HEAD", reverse: true)
+        let hashes = output.split(separator: "\n").map { String($0) }
+        XCTAssertEqual(hashes, [c1, c2])
+    }
+
+    func test_revList_customFormatRoundTrips() throws {
+        let base = try repo.head()
+        let hash = try repo.commitFile(path: "f.txt", content: "f", message: "subject here")
+
+        let output = try sut.revList(range: "\(base)..HEAD", format: "%H|%s")
+        XCTAssertTrue(output.contains("\(hash)|subject here"))
+    }
+
+    func test_revList_invalidRange_throws() throws {
+        XCTAssertThrowsError(try sut.revList(range: "bogus..HEAD")) { error in
+            guard case ShellRunner.Error.commandFailed = error else {
+                return XCTFail("expected ShellRunner.Error.commandFailed, got \(error)")
+            }
+        }
+    }
+}

--- a/Tests/GitoTests/RevListTests.swift
+++ b/Tests/GitoTests/RevListTests.swift
@@ -1,54 +1,57 @@
 import Foundation
-import XCTest
+import Testing
 import Corredor
 @testable import Gito
 
-final class RevListTests: XCTestCase {
-    var repo: TempRepo!
-    var sut: Gito!
+@Suite
+final class RevListTests {
+    let repo: TempRepo
+    let sut: Gito
 
-    override func setUpWithError() throws {
+    init() throws {
         repo = try TempRepo()
         sut = Gito(in: repo.url)
     }
 
-    override func tearDownWithError() throws {
-        try repo.tearDown()
+    deinit {
+        try? repo.tearDown()
     }
 
-    func test_revList_listsCommitsInRange() throws {
+    @Test
+    func revList_listsCommitsInRange() throws {
         let base = try repo.head()
         let c1 = try repo.commitFile(path: "1.txt", content: "1", message: "first")
         let c2 = try repo.commitFile(path: "2.txt", content: "2", message: "second")
 
         let output = try sut.revList(range: "\(base)..HEAD")
         let hashes = output.split(separator: "\n").map { String($0) }
-        XCTAssertEqual(hashes, [c2, c1]) // newest first by default
+        #expect(hashes == [c2, c1]) // newest first by default
     }
 
-    func test_revList_reverseGivesOldestFirst() throws {
+    @Test
+    func revList_reverseGivesOldestFirst() throws {
         let base = try repo.head()
         let c1 = try repo.commitFile(path: "1.txt", content: "1", message: "first")
         let c2 = try repo.commitFile(path: "2.txt", content: "2", message: "second")
 
         let output = try sut.revList(range: "\(base)..HEAD", reverse: true)
         let hashes = output.split(separator: "\n").map { String($0) }
-        XCTAssertEqual(hashes, [c1, c2])
+        #expect(hashes == [c1, c2])
     }
 
-    func test_revList_customFormatRoundTrips() throws {
+    @Test
+    func revList_customFormatRoundTrips() throws {
         let base = try repo.head()
         let hash = try repo.commitFile(path: "f.txt", content: "f", message: "subject here")
 
         let output = try sut.revList(range: "\(base)..HEAD", format: "%H|%s")
-        XCTAssertTrue(output.contains("\(hash)|subject here"))
+        #expect(output.contains("\(hash)|subject here"))
     }
 
-    func test_revList_invalidRange_throws() throws {
-        XCTAssertThrowsError(try sut.revList(range: "bogus..HEAD")) { error in
-            guard case ShellRunner.Error.commandFailed = error else {
-                return XCTFail("expected ShellRunner.Error.commandFailed, got \(error)")
-            }
+    @Test
+    func revList_invalidRange_throws() {
+        #expect(throws: ShellRunner.Error.self) {
+            try sut.revList(range: "bogus..HEAD")
         }
     }
 }

--- a/Tests/GitoTests/TempRepo.swift
+++ b/Tests/GitoTests/TempRepo.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Minimal temp git repo for tests. Initialises a repo, configures a user,
+/// and exposes helpers for seeding commits. Cleaned up via `tearDown()`.
+final class TempRepo {
+    let url: URL
+
+    init() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gito-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        self.url = dir
+        try git("init", "-b", "main")
+        try git("config", "user.email", "test@example.com")
+        try git("config", "user.name", "Test")
+        try git("commit", "--allow-empty", "-m", "root")
+    }
+
+    func tearDown() throws {
+        try FileManager.default.removeItem(at: url)
+    }
+
+    @discardableResult
+    func git(_ args: String...) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + args
+        process.currentDirectoryURL = url
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw NSError(
+                domain: "TempRepo",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "git \(args.joined(separator: " ")) failed: \(String(data: data, encoding: .utf8) ?? "")"]
+            )
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    /// Writes a file and commits it. Returns the new HEAD hash.
+    @discardableResult
+    func commitFile(path: String, content: String, message: String) throws -> String {
+        try content.write(to: url.appendingPathComponent(path), atomically: true, encoding: .utf8)
+        try git("add", path)
+        try git("commit", "-m", message)
+        return try git("rev-parse", "HEAD").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func head() throws -> String {
+        try git("rev-parse", "HEAD").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
Adds the operations a multi-branch cherry-pick flow needs. All new
ops use the existing `Shell.command` wrapper, matching the rest of
the repo. Methods that have meaningful exit-1 semantics catch the
error and pattern-match the exit code.

## API

```
cherryPick(hash:, recordOrigin: true) -> CherryPickOutcome
    .applied | .conflict(output:) | .empty
cherryPickSkip()
cherryPickAbort()
revList(range:, reverse: false, format: nil) -> String
mergeBase(_ a:, _ b:) -> String?            // nil for unrelated histories
isAncestor(_ commit:, of ref:) -> Bool      // exit 1 = false, >=2 throws
```

`cherryPick` is split into three methods because only the apply path
has meaningful exit-1 outcomes; skip and abort just run or throw.
`.empty` covers the "previous cherry-pick is now empty" case so
callers can distinguish a no-op pick from a real conflict.

## Additive overloads

```
commit(message:, noVerify: Bool, allowEmpty: Bool = false)
checkout(branch:, options: [String], startPoint: String)
```

Both build the underlying string via `Shell.command`. The existing
1-arg `commit(message:)` and 2-arg `checkout(branch:options:)` keep
their original implementation.

## Other changes

`Gito.folder` is now `internal` (was `private`) so the new extension
files in the same module can pass `in: folder`. Nothing leaks to
consumers.

## Tests

17 tests against a `TempRepo` helper that `git init`s a real repo in
`tmp`, seeds commits, tears down. Cherry-pick conflict and `.empty`
are provoked via real branches modifying the same line. Existing
tests untouched.

## Caller

platamator's `CherryPicker` is the immediate consumer. The platamator
MR for the swap is pending this tag.